### PR TITLE
fix: _timeout in scottidler script; default symlink not shown in list

### DIFF
--- a/src/statusline.rs
+++ b/src/statusline.rs
@@ -26,7 +26,7 @@ fn entry_names() -> Vec<&'static str> {
     let mut names: Vec<&'static str> = STATUSLINE_DIR
         .files()
         .filter_map(|f| f.path().file_name()?.to_str())
-        .filter(|name| !name.starts_with('.'))
+        .filter(|name| !name.starts_with('.') && *name != "default")
         .collect();
     names.sort_unstable();
     names
@@ -74,7 +74,10 @@ fn claude_dir() -> Result<PathBuf> {
 }
 
 pub fn install(name: Option<&str>) -> Result<()> {
-    let name = name.unwrap_or(DEFAULT_NAME);
+    let name = match name {
+        None | Some("default") => DEFAULT_NAME,
+        Some(n) => n,
+    };
     let dest = claude_dir()?;
     install_to(name, &dest)
 }

--- a/statusline.d/scottidler
+++ b/statusline.d/scottidler
@@ -2,6 +2,18 @@
 # Claude Code custom status line - two-line powerline style
 set -euo pipefail
 
+# Cross-platform timeout: GNU timeout → Homebrew gtimeout → perl fallback
+_timeout() {
+  local secs=$1; shift
+  if command -v timeout &>/dev/null; then
+    timeout "$secs" "$@"
+  elif command -v gtimeout &>/dev/null; then
+    gtimeout "$secs" "$@"
+  else
+    perl -e 'alarm shift @ARGV; exec @ARGV' "$secs" "$@"
+  fi
+}
+
 DATA=$(cat)
 
 # Parse all fields in one jq call
@@ -93,9 +105,9 @@ end_seg() {
 }
 
 # --- Cost via ccu ---
-TODAY_COST=$(timeout 1s ccu today --total 2>/dev/null || echo "0")
-WEEK_COST=$(timeout 1s ccu weekly --total -w 1 2>/dev/null || echo "0")
-MONTH_COST=$(timeout 1s ccu monthly --total -m 1 2>/dev/null || echo "0")
+TODAY_COST=$(_timeout 1 ccu today --total 2>/dev/null || echo "0")
+WEEK_COST=$(_timeout 1 ccu weekly --total -w 1 2>/dev/null || echo "0")
+MONTH_COST=$(_timeout 1 ccu monthly --total -m 1 2>/dev/null || echo "0")
 
 # --- Format duration ---
 DS=$((DURATION_MS/1000)); DM=$((DS/60)); DH=$((DM/60)); DM=$((DM%60))


### PR DESCRIPTION
## Summary
- Applies the same `_timeout()` cross-platform wrapper from PR #5 to `statusline.d/scottidler` (the actual installed script, not just the README example)
- Filters the `default` symlink from `--list` output - it was showing up as a redundant entry alongside `scottidler (default)`, making it look like a directory/separate statusline rather than an alias
- `install()` now explicitly handles `"default"` as an alias for `DEFAULT_NAME`, so `ccu statusline default` still works correctly

## Test plan
- [ ] `ccu statusline --list` shows only `scottidler (default)`, not a separate `default` entry
- [ ] `ccu statusline default` installs the scottidler script
- [ ] `ccu statusline` (no arg) installs the scottidler script
- [ ] Verify `_timeout` works on macOS (no GNU coreutils) and Linux