### PR TITLE
add claude-opus-4-7 pricing

### DIFF
--- a/data/pricing.yml
+++ b/data/pricing.yml
@@ -1,4 +1,11 @@
 pricing:
+  claude-opus-4-7:
+    input_per_mtok: 5
+    output_per_mtok: 25
+    cache_5m_write_per_mtok: 6.25
+    cache_1h_write_per_mtok: 10
+    cache_read_per_mtok: 0.5
+
   claude-opus-4-6:
     input_per_mtok: 5
     output_per_mtok: 25

--- a/src/pricing.rs
+++ b/src/pricing.rs
@@ -42,7 +42,7 @@ const LONG_CONTEXT_THRESHOLD: u64 = 200_000;
 pub fn normalize_model_id(model_id: &str) -> &str {
     // Bare names -> latest version
     match model_id {
-        "opus" => return "claude-opus-4-6",
+        "opus" => return "claude-opus-4-7",
         "sonnet" => return "claude-sonnet-4-6",
         "haiku" => return "claude-haiku-4-5",
         _ => {}
@@ -198,7 +198,7 @@ mod tests {
 
     #[test]
     fn test_normalize_model_id_bare_names() {
-        assert_eq!(normalize_model_id("opus"), "claude-opus-4-6");
+        assert_eq!(normalize_model_id("opus"), "claude-opus-4-7");
         assert_eq!(normalize_model_id("sonnet"), "claude-sonnet-4-6");
         assert_eq!(normalize_model_id("haiku"), "claude-haiku-4-5");
     }


### PR DESCRIPTION
Adds Claude Opus 4.7 to pricing data at $5/$25 per MTok (same tier as Opus 4.6). Updates bare `opus` alias to resolve to latest model.