### PR TITLE
Fix dedupe for streaming/duplicated assistant messages + stale-tier warning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "ccu"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccu"
-version = "0.3.21"
+version = "0.3.22"
 edition = "2024"
 authors = ["Scott Idler <scott.a.idler@gmail.com>"]
 build = "build.rs"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -10,7 +10,7 @@ use std::time::SystemTime;
 
 use crate::scanner::SessionFile;
 
-const CACHE_VERSION: u64 = 2;
+const CACHE_VERSION: u64 = 3;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CachedDay {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,12 +2,12 @@
 #![deny(dead_code)]
 #![deny(unused_variables)]
 
-use chrono::{Datelike, Local, NaiveDate};
+use chrono::{DateTime, Datelike, Local, NaiveDate, Utc};
 use clap::{CommandFactory, FromArgMatches};
 use eyre::{Context, Result};
 use log::{debug, info, warn};
 use rayon::prelude::*;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs;
 use std::path::PathBuf;
 
@@ -134,9 +134,23 @@ fn compute_summaries(
 
     // Group by day and session, compute costs
     let mut day_costs: BTreeMap<NaiveDate, (f64, HashSet<String>)> = BTreeMap::new();
-    let mut session_costs: BTreeMap<String, (f64, usize, chrono::DateTime<chrono::Utc>)> = BTreeMap::new();
+    let mut session_costs: BTreeMap<String, (f64, usize, DateTime<Utc>)> = BTreeMap::new();
 
     let mut warned_models: HashSet<String> = HashSet::new();
+
+    // Dedupe pass: Claude Code emits multiple copies of each assistant message to the
+    // JSONL file - partial streaming states with incomplete output_tokens, then a final
+    // complete copy. Additionally, session resumption can duplicate entries. Keep the
+    // highest-cost copy per (message.id, requestId), which corresponds to the final
+    // complete message Anthropic actually bills for.
+    struct DedupedEntry {
+        cost: f64,
+        date: NaiveDate,
+        session_id: String,
+        timestamp: DateTime<Utc>,
+    }
+    let mut deduped: HashMap<(String, Option<String>), DedupedEntry> = HashMap::new();
+    let mut no_mid_entries: Vec<DedupedEntry> = Vec::new();
 
     for entry in &all_entries {
         // Skip synthetic entries (internal Claude Code artifacts, not real API calls)
@@ -149,15 +163,15 @@ fn compute_summaries(
             continue;
         }
 
+        let normalized = pricing::normalize_model_id(&entry.model);
+
         // Apply model filter if specified
-        if let Some(ref model_filter) = cli.model {
-            let normalized = pricing::normalize_model_id(&entry.model);
-            if normalized != model_filter {
-                continue;
-            }
+        if let Some(ref model_filter) = cli.model
+            && normalized != model_filter
+        {
+            continue;
         }
 
-        let normalized = pricing::normalize_model_id(&entry.model);
         let model_pricing = match config.pricing.get(normalized) {
             Some(p) => p,
             None => {
@@ -170,17 +184,48 @@ fn compute_summaries(
 
         let cost = pricing::calculate_cost(model_pricing, &entry.usage);
 
-        let day_entry = day_costs.entry(date).or_insert_with(|| (0.0, HashSet::new()));
-        day_entry.0 += cost;
-        day_entry.1.insert(entry.session_id.clone());
+        let deduped_entry = DedupedEntry {
+            cost,
+            date,
+            session_id: entry.session_id.clone(),
+            timestamp: entry.timestamp,
+        };
+
+        match &entry.message_id {
+            Some(mid) => {
+                let key = (mid.clone(), entry.request_id.clone());
+                deduped
+                    .entry(key)
+                    .and_modify(|existing| {
+                        if cost > existing.cost {
+                            existing.cost = cost;
+                            existing.date = date;
+                            existing.session_id = entry.session_id.clone();
+                            existing.timestamp = entry.timestamp;
+                        }
+                    })
+                    .or_insert(deduped_entry);
+            }
+            None => {
+                // No reliable dedup key: count as-is
+                no_mid_entries.push(deduped_entry);
+            }
+        }
+    }
+
+    // Aggregate deduped entries into day and session summaries
+    for de in deduped.values().chain(no_mid_entries.iter()) {
+        let day_entry = day_costs.entry(de.date).or_insert_with(|| (0.0, HashSet::new()));
+        day_entry.0 += de.cost;
+        day_entry.1.insert(de.session_id.clone());
 
         let session_entry = session_costs
-            .entry(entry.session_id.clone())
-            .or_insert((0.0, 0, entry.timestamp));
-        session_entry.0 += cost;
+            .entry(de.session_id.clone())
+            .or_insert((0.0, 0, de.timestamp));
+        session_entry.0 += de.cost;
         session_entry.1 += 1;
-        if entry.timestamp > session_entry.2 {
-            session_entry.2 = entry.timestamp;
+        if de.timestamp > session_entry.2 {
+            session_entry.2 = de.timestamp;
         }
     }
 
@@ -557,8 +602,53 @@ fn main() -> Result<()> {
     // Load config: embedded pricing as base, config file as override
     let mut config = Config::load(cli.config.as_ref()).context("Failed to load configuration")?;
 
-    // Merge: embedded pricing is the base layer, config file pricing overrides
+    // Detect stale >200K tier pricing in user config. Anthropic eliminated the >200K
+    // long-context surcharge on 2026-03-13. Pre-2026-03-11 ccu installs auto-wrote
+    // ~/.config/ccu/ccu.yml with the then-current tiered pricing, and that file is
+    // never rewritten. Left in place, it over-bills any request with >200K input tokens.
     let embedded = pricing::default_pricing();
+    let stale_models: Vec<&String> = config
+        .pricing
+        .iter()
+        .filter(|(model, user_pricing)| {
+            let user_has_premium = user_pricing.input_per_mtok_above_200k.is_some()
+                || user_pricing.output_per_mtok_above_200k.is_some()
+                || user_pricing.cache_5m_write_per_mtok_above_200k.is_some()
+                || user_pricing.cache_1h_write_per_mtok_above_200k.is_some()
+                || user_pricing.cache_read_per_mtok_above_200k.is_some();
+            if !user_has_premium {
+                return false;
+            }
+            match embedded.get(*model) {
+                Some(emb) => {
+                    emb.input_per_mtok_above_200k.is_none()
+                        && emb.output_per_mtok_above_200k.is_none()
+                        && emb.cache_5m_write_per_mtok_above_200k.is_none()
+                        && emb.cache_1h_write_per_mtok_above_200k.is_none()
+                        && emb.cache_read_per_mtok_above_200k.is_none()
+                }
+                None => false,
+            }
+        })
+        .map(|(model, _)| model)
+        .collect();
+
+    if !stale_models.is_empty() {
+        let mut models: Vec<&str> = stale_models.iter().map(|s| s.as_str()).collect();
+        models.sort();
+        eprintln!(
+            "warning: your ~/.config/ccu/ccu.yml has stale *_above_200k pricing tiers for: {}.\n\
+             Anthropic eliminated the >200K long-context surcharge for these models on 2026-03-13,\n\
+             so leaving them in place over-bills any request with >200K input tokens.\n\
+             \n\
+             To fix, either:\n  \
+               - delete ~/.config/ccu/ccu.yml entirely (the binary's embedded pricing covers everything), or\n  \
+               - remove just the *_above_200k lines from the affected model entries.\n",
+            models.join(", ")
+        );
+    }
+
+    // Merge: embedded pricing is the base layer, config file pricing overrides
     let mut effective = embedded;
     for (model, model_pricing) in config.pricing.drain() {
         effective.insert(model, model_pricing);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -20,6 +20,10 @@ pub struct AssistantEntry {
     pub timestamp: DateTime<Utc>,
     pub model: String,
     pub usage: TokenUsage,
+    // Anthropic's canonical message ID (e.g. "msg_01AbC..."). Used to dedupe
+    // entries copied across session files when Claude Code resumes/forks a session.
+    pub message_id: Option<String>,
+    pub request_id: Option<String>,
 }
 
 // Serde structures for JSONL parsing - only the fields we need
@@ -31,10 +35,13 @@ struct RawEntry {
     session_id: Option<String>,
     timestamp: Option<String>,
     message: Option<RawMessage>,
+    #[serde(rename = "requestId")]
+    request_id: Option<String>,
 }
 
 #[derive(Deserialize)]
 struct RawMessage {
+    id: Option<String>,
     model: Option<String>,
     usage: Option<RawUsage>,
 }
@@ -103,7 +110,9 @@ fn convert_raw_entry(raw: RawEntry) -> Option<AssistantEntry> {
 
     let session_id = raw.session_id?;
     let timestamp_str = raw.timestamp?;
+    let request_id = raw.request_id;
     let message = raw.message?;
+    let message_id = message.id;
     let model = message.model?;
     let usage = message.usage?;
 
@@ -130,6 +139,8 @@ fn convert_raw_entry(raw: RawEntry) -> Option<AssistantEntry> {
             cache_1h_write_tokens: cache_1h,
             cache_read_tokens: usage.cache_read_input_tokens.unwrap_or(0),
         },
+        message_id,
+        request_id,
     })
 }
 
@@ -157,7 +168,7 @@ mod tests {
     #[test]
     fn test_parse_assistant_entry() {
         let jsonl = make_jsonl_file(&[
-            r#"{"type":"assistant","sessionId":"abc-123","timestamp":"2026-03-10T14:23:01.025Z","message":{"model":"claude-opus-4-6","usage":{"input_tokens":100,"output_tokens":50,"cache_creation_input_tokens":200,"cache_read_input_tokens":1000,"cache_creation":{"ephemeral_5m_input_tokens":200,"ephemeral_1h_input_tokens":0}}}}"#,
+            r#"{"type":"assistant","sessionId":"abc-123","timestamp":"2026-03-10T14:23:01.025Z","requestId":"req_1","message":{"id":"msg_abc","model":"claude-opus-4-6","usage":{"input_tokens":100,"output_tokens":50,"cache_creation_input_tokens":200,"cache_read_input_tokens":1000,"cache_creation":{"ephemeral_5m_input_tokens":200,"ephemeral_1h_input_tokens":0}}}}"#,
         ]);
 
         let entries = parse_jsonl_file(jsonl.path()).expect("parse");
@@ -167,6 +178,42 @@ mod tests {
         assert_eq!(entries[0].usage.output_tokens, 50);
         assert_eq!(entries[0].usage.cache_5m_write_tokens, 200);
         assert_eq!(entries[0].usage.cache_read_tokens, 1000);
+        assert_eq!(entries[0].message_id.as_deref(), Some("msg_abc"));
+        assert_eq!(entries[0].request_id.as_deref(), Some("req_1"));
+    }
+
+    #[test]
+    fn test_parse_captures_message_id_for_dedup() {
+        // Same message.id duplicated across two files (simulates session resumption).
+        // Parser returns both; dedup happens in the caller.
+        let line = r#"{"type":"assistant","sessionId":"s1","timestamp":"2026-03-10T14:23:01.025Z","requestId":"req_1","message":{"id":"msg_dupe","model":"claude-opus-4-6","usage":{"input_tokens":10,"output_tokens":5}}}"#;
+        let f1 = make_jsonl_file(&[line]);
+        let f2 = make_jsonl_file(&[line]);
+
+        let e1 = parse_jsonl_file(f1.path()).expect("parse f1");
+        let e2 = parse_jsonl_file(f2.path()).expect("parse f2");
+        assert_eq!(e1.len(), 1);
+        assert_eq!(e2.len(), 1);
+        assert_eq!(e1[0].message_id, e2[0].message_id);
+        assert_eq!(e1[0].message_id.as_deref(), Some("msg_dupe"));
+    }
+
+    #[test]
+    fn test_parse_streaming_partial_copies() {
+        // Claude Code writes partial streaming states followed by a final complete copy,
+        // all with the same (message.id, requestId). Parser returns all copies; the dedup
+        // pass in main.rs is responsible for selecting the authoritative one by max cost.
+        let jsonl = make_jsonl_file(&[
+            r#"{"type":"assistant","sessionId":"s1","timestamp":"2026-03-10T14:23:01Z","requestId":"req_x","message":{"id":"msg_stream","model":"claude-opus-4-6","usage":{"input_tokens":1,"output_tokens":8,"cache_creation_input_tokens":100,"cache_read_input_tokens":500}}}"#,
+            r#"{"type":"assistant","sessionId":"s1","timestamp":"2026-03-10T14:23:01Z","requestId":"req_x","message":{"id":"msg_stream","model":"claude-opus-4-6","usage":{"input_tokens":1,"output_tokens":315,"cache_creation_input_tokens":100,"cache_read_input_tokens":500}}}"#,
+        ]);
+
+        let entries = parse_jsonl_file(jsonl.path()).expect("parse");
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].usage.output_tokens, 8);
+        assert_eq!(entries[1].usage.output_tokens, 315);
+        assert_eq!(entries[0].message_id, entries[1].message_id);
+        assert_eq!(entries[0].request_id, entries[1].request_id);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Dedupe assistant messages by `(message.id, requestId)` keeping the highest-cost copy. Claude Code emits partial streaming copies plus a final complete copy; session resumption can also duplicate entries. Prior code double-counted ~1.8x on real data.
- Warn at startup when the user's `~/.config/ccu/ccu.yml` contains `*_above_200k` tier pricing for models whose embedded pricing omits them. Pre-2026-03-11 ccu auto-wrote a config with the then-current >200K surcharge tiers, Anthropic eliminated those surcharges on 2026-03-13, and the binary can't rewrite user files. The warning tells affected users they can either delete the file or strip just the stale lines.
- `CACHE_VERSION` bumped 2 -> 3 to invalidate pre-fix day totals.
- Parser now captures `message.id` + `requestId` on each `AssistantEntry`; added tests for both cross-file dedup and within-file streaming partial copies.

## Impact

On real JSONL data (Scott's ~/.claude/projects across 115 projects / 623 files):

| | April 2026 |
|---|---|
| Before | $4,649.80 |
| After dedup + clean config | $2,038.85 |
| Anthropic dashboard | $2,090.24 |

~2.5% residual vs Anthropic, within normal noise.

## Test plan

- [x] `cargo test` - all 92 tests pass
- [x] Verified warning fires for stale `_above_200k` config
- [x] Verified no warning on clean config
- [x] Compared month/day output against Anthropic Admin dashboard on real data