### PR TITLE
fix: use XDG config path and show actual path in stale pricing warning

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,16 @@ use std::path::{Path, PathBuf};
 
 use crate::pricing::ModelPricing;
 
+/// Returns the XDG config directory: $XDG_CONFIG_HOME if set, else ~/.config.
+fn xdg_config_dir() -> Option<PathBuf> {
+    if let Ok(val) = std::env::var("XDG_CONFIG_HOME")
+        && !val.is_empty()
+    {
+        return Some(PathBuf::from(val));
+    }
+    dirs::home_dir().map(|h| h.join(".config"))
+}
+
 #[derive(Debug, Default, Deserialize, Serialize)]
 #[serde(default)]
 pub struct Config {
@@ -18,19 +28,22 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn load(config_path: Option<&PathBuf>) -> Result<Self> {
+    /// Load config and return the resolved path it was loaded from (None if using defaults).
+    pub fn load(config_path: Option<&PathBuf>) -> Result<(Self, Option<PathBuf>)> {
         log::debug!("Config::load: config_path={:?}", config_path);
 
         if let Some(path) = config_path {
-            return Self::load_from_file(path).context(format!("Failed to load config from {}", path.display()));
+            let config =
+                Self::load_from_file(path).context(format!("Failed to load config from {}", path.display()))?;
+            return Ok((config, Some(path.clone())));
         }
 
-        // Try ~/.config/ccu/ccu.yml
-        if let Some(config_dir) = dirs::config_dir() {
+        // Try XDG config dir ($XDG_CONFIG_HOME, or ~/.config)
+        if let Some(config_dir) = xdg_config_dir() {
             let primary_config = config_dir.join("ccu").join("ccu.yml");
             if primary_config.exists() {
                 match Self::load_from_file(&primary_config) {
-                    Ok(config) => return Ok(config),
+                    Ok(config) => return Ok((config, Some(primary_config))),
                     Err(e) => {
                         log::warn!("Failed to load config from {}: {}", primary_config.display(), e);
                     }
@@ -40,7 +53,7 @@ impl Config {
 
         // No config file found - return empty config; caller merges embedded pricing
         log::info!("No config file found, using embedded pricing defaults");
-        Ok(Config::default())
+        Ok((Config::default(), None))
     }
 
     fn load_from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
@@ -81,5 +94,21 @@ mod tests {
         // It returns either the loaded config or a default with empty pricing.
         let result = Config::load(None);
         assert!(result.is_ok(), "Config::load(None) should not error");
+    }
+
+    #[test]
+    fn test_load_returns_path_for_explicit_config() {
+        let path = PathBuf::from("/nonexistent/path/ccu.yml");
+        let result = Config::load(Some(&path));
+        // explicit missing path should error, not return None
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_load_returns_none_path_when_no_config() {
+        // When no config file exists, path should be None
+        // (we can't guarantee no config exists in test env, just check it doesn't panic)
+        let result = Config::load(None);
+        assert!(result.is_ok());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -600,7 +600,7 @@ fn main() -> Result<()> {
     }
 
     // Load config once; use its log_level to initialize logging.
-    let mut config = Config::load(cli.config.as_ref()).context("Failed to load configuration")?;
+    let (mut config, config_path) = Config::load(cli.config.as_ref()).context("Failed to load configuration")?;
     let (filter, has_explicit_level) = resolve_log_filter(cli.log_level.as_deref(), config.log_level.as_deref());
     setup_logging(&filter, has_explicit_level).context("Failed to setup logging")?;
 
@@ -638,15 +638,20 @@ fn main() -> Result<()> {
     if !stale_models.is_empty() {
         let mut models: Vec<&str> = stale_models.iter().map(|s| s.as_str()).collect();
         models.sort();
+        let path_display = config_path
+            .as_deref()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|| "<unknown config path>".to_string());
         eprintln!(
-            "warning: your ~/.config/ccu/ccu.yml has stale *_above_200k pricing tiers for: {}.\n\
+            "warning: your {path} has stale *_above_200k pricing tiers for: {models}.\n\
              Anthropic eliminated the >200K long-context surcharge for these models on 2026-03-13,\n\
              so leaving them in place over-bills any request with >200K input tokens.\n\
              \n\
              To fix, either:\n  \
-               - delete ~/.config/ccu/ccu.yml entirely (the binary's embedded pricing covers everything), or\n  \
+               - delete {path} entirely (the binary's embedded pricing covers everything), or\n  \
                - remove just the *_above_200k lines from the affected model entries.\n",
-            models.join(", ")
+            path = path_display,
+            models = models.join(", ")
         );
     }
 


### PR DESCRIPTION
## Summary

- Replace `dirs::config_dir()` (returns `~/Library/Application Support` on macOS) with a new `xdg_config_dir()` helper that respects `$XDG_CONFIG_HOME` and falls back to `~/.config` on all platforms
- `Config::load()` now returns the resolved config path alongside the `Config` struct
- The stale `*_above_200k` pricing warning now displays the **actual file path** to delete rather than a hard-coded `~/.config/ccu/ccu.yml` string

## Background

Two bugs were found together:
1. On macOS, `ccu` stored its config at `~/Library/Application Support/ccu/ccu.yml` but the stale-pricing warning told users to delete `~/.config/ccu/ccu.yml` — deleting the wrong file left the warning firing indefinitely and costs inflated ~2.2x due to stale `*_above_200k` tiers
2. Root cause: `dirs::config_dir()` is platform-specific; switching to XDG convention fixes both the storage location and the warning message in one change

## Test plan

- [ ] `cargo test` passes (94 tests)
- [ ] On macOS: `ccu monthly` config now lives at `~/.config/ccu/ccu.yml`
- [ ] Stale pricing warning shows the correct path that was actually loaded
- [ ] `$XDG_CONFIG_HOME` override is respected when set