### PR TITLE
Add Nerd Fonts powerline statusline example

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,17 @@ echo "$MODEL | ctx:$CTX | M\$$MONTH_COST W\$$WEEK_COST D\$$TODAY_COST S\$$SESSIO
 
 ### Full Powerline-Style Statusline
 
-For a polished statusline with ANSI colors, powerline arrows, git branch, color-coded context usage, and theme support, see:
+For a polished statusline with ANSI colors, powerline arrows, git branch, color-coded context usage, and theme support, see the examples in [`statusline.d/`](statusline.d/):
 
-- [scottidler/claude - statusline.sh](https://github.com/scottidler/claude/blob/main/statusline.sh)
+- [`statusline.d/scottidler`](statusline.d/scottidler) — the original two-line powerline statusline with catppuccin-mocha theme support
+- [`statusline.d/nerdfonts`](statusline.d/nerdfonts) — **Nerd Fonts variant** with a dark matrix/cyberpunk palette, Nerd Font glyphs for every segment, and a dot-bar context indicator (requires a [Nerd Fonts](https://www.nerdfonts.com) patched terminal font)
+
+To install either, copy it to `~/.claude/statusline.sh` and make it executable:
+
+```bash
+cp statusline.d/nerdfonts ~/.claude/statusline.sh
+chmod +x ~/.claude/statusline.sh
+```
 
 ### Other Options
 

--- a/statusline.d/nerdfonts
+++ b/statusline.d/nerdfonts
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+# Claude Code custom status line - two-line powerline style with Nerd Fonts
+#
+# Requirements:
+#   - A Nerd Fonts patched font set as your terminal font (https://www.nerdfonts.com)
+#   - jq, git, ccu (this tool)
+#
+# Color theme: dark matrix/cyberpunk palette derived from claude-powerline.json
+#   directory  #1a1100 / #ffbb00   (amber)
+#   git        #0d1a0d / #00ff41   (matrix green)
+#   context    #001122 / #00d4ff   (navy / cyan)
+#   model      #0d0a1a / #c084fc   (deep purple)
+#
+# Feature flags (env vars):
+#   CLAUDE_CTX_DOTS=0   disable filled/unfilled dot bar beside context % (default: on)
+#   CLAUDE_COLORSCHEME  name of a scheme file in CLAUDE_COLORSCHEME_DIR (optional)
+#
+# Install: copy to ~/.claude/statusline.sh and make executable
+set -euo pipefail
+
+# Cross-platform timeout: GNU timeout → Homebrew gtimeout → perl fallback
+_timeout() {
+    local secs=$1; shift
+    if command -v timeout &>/dev/null; then
+        timeout "$secs" "$@"
+    elif command -v gtimeout &>/dev/null; then
+        gtimeout "$secs" "$@"
+    else
+        perl -e 'alarm shift @ARGV; exec @ARGV' "$secs" "$@"
+    fi
+}
+
+DATA=$(cat)
+
+# Parse all fields in one jq call
+eval "$(echo "$DATA" | jq -r '
+  @sh "MODEL=\(.model.display_name // .model.id // "?")",
+  @sh "USED_PCT=\(.context_window.used_percentage // "")",
+  @sh "CTX_SIZE=\(.context_window.context_window_size // 0)",
+  @sh "SESSION_COST=\(.cost.total_cost_usd // 0)",
+  @sh "DURATION_MS=\(.cost.total_duration_ms // 0)",
+  @sh "LINES_ADDED=\(.cost.total_lines_added // 0)",
+  @sh "LINES_REMOVED=\(.cost.total_lines_removed // 0)",
+  @sh "CWD=\(.workspace.current_dir // .cwd // "")",
+  @sh "TOK_IN=\(.context_window.total_input_tokens // 0)",
+  @sh "TOK_OUT=\(.context_window.total_output_tokens // 0)"
+')"
+
+# Shorten model name
+MODEL=$(echo "$MODEL" | sed -e 's/ ([^)]*context[^)]*)//g' -e 's/Opus [0-9.]*/opus/' -e 's/Sonnet [0-9.]*/sonnet/' -e 's/Haiku [0-9.]*/haiku/')
+
+# Format context window size
+if [[ "$CTX_SIZE" -ge 1000000 ]]; then
+    CTX_WIN="$(awk "BEGIN{printf \"%.0fM\",$CTX_SIZE/1000000}")"
+elif [[ "$CTX_SIZE" -ge 1000 ]]; then
+    CTX_WIN="$(awk "BEGIN{printf \"%.0fK\",$CTX_SIZE/1000}")"
+else
+    CTX_WIN="$CTX_SIZE"
+fi
+
+# --- Format tokens ---
+fmt_tok() {
+    local t="$1"
+    if [[ $t -ge 1000000 ]]; then
+        awk -v t="$t" 'BEGIN{printf "%.1fM", t/1000000}'
+    elif [[ $t -ge 1000 ]]; then
+        awk -v t="$t" 'BEGIN{printf "%.0fK", t/1000}'
+    else
+        echo "$t"
+    fi
+}
+TOK_IN_FMT=$(fmt_tok "$TOK_IN")
+TOK_OUT_FMT=$(fmt_tok "$TOK_OUT")
+
+# --- ANSI helpers ---
+RST=$'\033[0m'
+BOLD=$'\033[1m'
+fg()  { printf '\033[38;5;%sm' "$1"; }
+bg()  { printf '\033[48;5;%sm' "$1"; }
+fgr() { printf '\033[38;2;%s;%s;%sm' "$1" "$2" "$3"; }
+bgr() { printf '\033[48;2;%s;%s;%sm' "$1" "$2" "$3"; }
+
+# --- Load color scheme (optional override) ---
+SCHEME="${CLAUDE_COLORSCHEME:-}"
+SCHEME_DIR="${CLAUDE_COLORSCHEME_DIR:-$HOME/.claude/statusline.d}"
+SCHEME_FILE="${SCHEME_DIR}/${SCHEME}.sh"
+
+if [[ -n "$SCHEME" && "$SCHEME" =~ ^[a-zA-Z0-9_-]+$ && -f "$SCHEME_FILE" ]]; then
+    source "$SCHEME_FILE"
+else
+    S0="5;5;10"; S1="10;10;20"; S2="15;15;30"; S3="20;20;40"
+    ACCENT_PRIMARY="0;212;255"; ACCENT_OK="0;255;65"
+    ACCENT_WARN="255;170;0"; ACCENT_CAUTION="255;187;0"
+    ACCENT_ERROR="255;51;51"; ACCENT_COST="0;212;255"
+    ACCENT_COST_SECONDARY="255;187;0"; ACCENT_MUTED="80;100;120"
+    TEXT="200;230;255"; SUBTEXT="150;180;210"
+fi
+
+PL=$'\ue0b0'
+PREV_BG=""
+OUT=""
+
+# --- Nerd Font icons ---
+IC_FOLDER=$'\uf07b'   # fa-folder          (CWD)
+IC_SERVER=$'\uf233'   # fa-server          (hostname)
+IC_BRANCH=$'\ue0a0'   # pl-branch          (git branch)
+IC_CPU=$'\uf4bc'      # fa-microchip       (model)
+IC_BAR=$'\uf080'      # fa-bar-chart       (context window)
+IC_DOWN=$'\uf019'     # fa-download        (tokens in)
+IC_UP=$'\uf093'       # fa-upload          (tokens out)
+IC_BOLT=$'\uf0e7'     # fa-bolt            (burn rate)
+IC_DOLLAR=$'\uf155'   # fa-dollar-sign     (cost)
+IC_CLOCK=$'\uf017'    # fa-clock-o         (duration)
+
+# seg <text> <bg_rgb> <fg_rgb>
+seg() {
+    local text="$1" sbg="$2" sfg="$3"
+    IFS=';' read -r br bg_ bb <<< "$sbg"
+    if [[ -n "$PREV_BG" ]]; then
+        IFS=';' read -r pr pg pb <<< "$PREV_BG"
+        OUT+="$(bgr "$br" "$bg_" "$bb")$(fgr "$pr" "$pg" "$pb")${PL}${RST}"
+    fi
+    IFS=';' read -r fr fg_ fb <<< "$sfg"
+    OUT+="$(bgr "$br" "$bg_" "$bb")$(fgr "$fr" "$fg_" "$fb") ${text}${RST}"
+    PREV_BG="$sbg"
+}
+
+end_seg() {
+    if [[ -n "$PREV_BG" ]]; then
+        IFS=';' read -r pr pg pb <<< "$PREV_BG"
+        OUT+="$(fgr "$pr" "$pg" "$pb")${PL}${RST}"
+    fi
+}
+
+# --- Cost via ccu ---
+TODAY_COST=$(_timeout 1 ccu today --total 2>/dev/null || echo "0")
+WEEK_COST=$(_timeout 1 ccu weekly --total -w 1 2>/dev/null || echo "0")
+MONTH_COST=$(_timeout 1 ccu monthly --total -m 1 2>/dev/null || echo "0")
+
+# --- Format duration ---
+DS=$((DURATION_MS/1000)); DM=$((DS/60)); DH=$((DM/60)); DM=$((DM%60))
+[[ $DH -gt 0 ]] && DUR="${DH}h${DM}m" || DUR="${DM}m"
+
+# --- Token burn rate (tok/h) ---
+TOTAL_TOKENS=$((TOK_IN + TOK_OUT))
+if [[ $DURATION_MS -gt 30000 && $TOTAL_TOKENS -gt 0 ]]; then
+    TOK_HR=$(awk -v t="$TOTAL_TOKENS" -v d="$DURATION_MS" 'BEGIN{printf "%.0f", t / (d / 3600000)}')
+    if [[ $TOK_HR -ge 1000000 ]]; then
+        TOK_HR_FMT="$(awk -v t="$TOK_HR" 'BEGIN{printf "%.1fM", t/1000000}')/h"
+    elif [[ $TOK_HR -ge 1000 ]]; then
+        TOK_HR_FMT="$(awk -v t="$TOK_HR" 'BEGIN{printf "%.0fK", t/1000}')/h"
+    else
+        TOK_HR_FMT="${TOK_HR}/h"
+    fi
+else
+    TOK_HR_FMT="..."
+fi
+
+# --- Context color + display ---
+# CLAUDE_CTX_DOTS=0 to disable the dot bar; dots are on by default.
+# 10 dots, each representing 10% of context used (floored to nearest dot).
+CTX_FG=$ACCENT_OK
+if [[ -n "$USED_PCT" && "$USED_PCT" != "null" ]]; then
+    case $(awk -v p="$USED_PCT" 'BEGIN{if(p>=70)print 4;else if(p>=60)print 3;else if(p>=50)print 2;else print 1}') in
+        4) CTX_FG=$ACCENT_ERROR ;;
+        3) CTX_FG=$ACCENT_CAUTION ;;
+        2) CTX_FG=$ACCENT_WARN ;;
+    esac
+    if [[ "${CLAUDE_CTX_DOTS:-1}" == "1" ]]; then
+        FILLED=$(awk -v p="$USED_PCT" 'BEGIN{n=int(p/10); if(n>10)n=10; print n}')
+        EMPTY=$((10 - FILLED))
+        DOTS=""
+        for ((i=0; i<FILLED; i++)); do DOTS+="●"; done
+        for ((i=0; i<EMPTY; i++)); do DOTS+="○"; done
+        CTX="${DOTS} ${USED_PCT}%"
+    else
+        CTX="${USED_PCT}%"
+    fi
+else
+    CTX="..."
+fi
+
+# --- Format costs ---
+fc() { awk -v c="$1" 'BEGIN{if(c<10)printf"%.2f",c;else if(c<100)printf"%.1f",c;else printf"%.0f",c}'; }
+S_COST=$(echo | fc "$SESSION_COST")
+T_COST=$(echo | fc "$TODAY_COST")
+W_COST=$(echo | fc "$WEEK_COST")
+M_COST=$(echo | fc "$MONTH_COST")
+
+# --- Git branch ---
+GIT_BRANCH=""
+if [[ -n "$CWD" ]] && git -C "$CWD" rev-parse --is-inside-work-tree &>/dev/null; then
+    GIT_BRANCH=$(git -C "$CWD" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+    if [[ -n "$GIT_BRANCH" ]]; then
+        [[ -n "$(git -C "$CWD" status --porcelain 2>/dev/null | head -1)" ]] && GIT_BRANCH+=" ●"
+    fi
+fi
+
+# --- Hostname ---
+HOSTNAME_SHORT=$(hostname -s 2>/dev/null || echo "?")
+
+# --- Shorten CWD ---
+DISPLAY_CWD="${CWD/#$HOME/\~}"
+
+# --- Inline color helpers ---
+bgr_split() { IFS=';' read -r r g b <<< "$1"; bgr "$r" "$g" "$b"; }
+fgr_split() { IFS=';' read -r r g b <<< "$1"; fgr "$r" "$g" "$b"; }
+
+# Line background and foreground colors (matrix/cyberpunk palette)
+L1_A="13;26;13"       # matrix git green bg  (#0d1a0d)
+L1_B="26;17;0"        # directory amber bg   (#1a1100)
+L1_C="0;17;34"        # hostname navy bg     (#001122)
+L2_A="0;17;34"        # context navy bg      (#001122)
+L2_B="13;10;26"       # model purple bg      (#0d0a1a)
+L1_A_FG="0;255;65"    # matrix green text    (#00ff41)
+L1_B_FG="255;187;0"   # amber yellow text    (#ffbb00)
+L1_C_FG="0;212;255"   # cyan text            (#00d4ff)
+L2_A_FG="0;212;255"   # cyan text            (#00d4ff)
+L2_B_FG="192;132;252" # soft purple text     (#c084fc)
+
+# =====================
+# LINE 1:  CWD |  hostname |  branch ● | +/- diff
+# =====================
+seg "${IC_FOLDER} ${DISPLAY_CWD} " "$L1_B" "$L1_B_FG"
+seg "${IC_SERVER} ${HOSTNAME_SHORT} " "$L1_C" "$L1_C_FG"
+
+if [[ -n "$GIT_BRANCH" ]]; then
+    seg "${IC_BRANCH} ${GIT_BRANCH} " "$L1_A" "$L1_A_FG"
+    if [[ "$LINES_ADDED" != "0" || "$LINES_REMOVED" != "0" ]]; then
+        seg " $(fgr_split $ACCENT_OK)+${LINES_ADDED}$(fgr_split $ACCENT_ERROR)-${LINES_REMOVED} " "$L1_C" "$L1_C_FG"
+    fi
+fi
+
+end_seg
+
+# =====================
+# LINE 2:  model(ctx) |  ●●●○○○○○○○ 30% |  tokens |  burn |  costs |  duration
+# =====================
+PREV_BG=""
+OUT+="\n"
+
+seg "${IC_CPU} ${MODEL}(${CTX_WIN}) " "$L2_B" "$L2_B_FG"
+seg "${IC_BAR} ${CTX} " "$L2_A" "$L2_A_FG"
+seg "${IC_DOWN}${TOK_IN_FMT} ${IC_UP}${TOK_OUT_FMT} " "$L2_B" "$L2_B_FG"
+seg "${IC_BOLT}${TOK_HR_FMT} " "$L2_A" "$L2_A_FG"
+seg "${IC_DOLLAR}${M_COST}$(fgr_split $L2_B_FG)|$(fgr_split $L2_B_FG)${IC_DOLLAR}${W_COST}$(fgr_split $L2_B_FG)|$(fgr_split $L2_B_FG)${IC_DOLLAR}${T_COST}$(fgr_split $L2_B_FG)|$(fgr_split $L2_B_FG)${IC_DOLLAR}${S_COST} " "$L2_B" "$L2_B_FG"
+seg "${IC_CLOCK} ${DUR} " "$L2_A" "$L2_A_FG"
+end_seg
+
+echo -e "$OUT"


### PR DESCRIPTION
## Summary

Adds a Nerd Fonts-friendly powerline statusline example to `statusline.d/`. The existing `scottidler` example uses emoji and plain ASCII symbols; this variant swaps in proper Nerd Font glyphs and introduces a dark matrix/cyberpunk color palette derived from the `claude-powerline` JSON theme format.

## Changes

- `statusline.d/nerdfonts` — new two-line powerline statusline with:
  - **Matrix/cyberpunk palette**: amber (CWD), navy (hostname), matrix green (git branch), deep purple (model), navy/cyan (context) — each segment visually distinct
  - **Nerd Font glyphs**: folder, server, branch, chip, bar-chart, download/upload, bolt, dollar, clock
  - **Dot-bar context indicator**: 10 filled/unfilled dots (●●●○○○○○○○) beside usage %, on by default, disable with `CLAUDE_CTX_DOTS=0`
  - Cross-platform `_timeout()` wrapper (GNU/gtimeout/perl fallback) matching `scottidler`
- `README.md` — updated the Full Powerline-Style Statusline section to list both examples with a one-line description each and a copy-install snippet

## Validation

Script is a drop-in replacement for `~/.claude/statusline.sh` — tested locally against live Claude Code sessions. No changes to `ccu` library code or build pipeline.