### PR TITLE
ci: add CODEOWNERS for the SRE team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# docs: https://tatari.atlassian.net/wiki/spaces/SRE/pages/1842610200/Github+Repo+Ownership
+## List teams that should be notified of PRs here.
+# You can also split into different paths for different teams.
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @tatari-tv/sre


### PR DESCRIPTION
Adds `.github/CODEOWNERS` so PRs are routed to @tatari-tv/sre. Matches the canonical pattern used in python-tatari-service-lib, base-images, rust-cli, etc.