### PR TITLE
deps: bump claude-pricing v0.1.0 -> v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,8 +206,8 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "claude-pricing"
-version = "0.1.0"
-source = "git+https://github.com/tatari-tv/claude-pricing?tag=v0.1.0#6c58aaa3ef9488e6e3fbc0f5c0dab540652bb295"
+version = "0.1.1"
+source = "git+https://github.com/tatari-tv/claude-pricing?tag=v0.1.1#704e902c76210708ae6c17c8029ee78be398abde"
 dependencies = [
  "chrono",
  "dirs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "ccu"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "Fast CLI tool for tracking Claude Code session costs from JSONL l
 
 [dependencies]
 chrono = "0.4.44"
-claude-pricing = { git = "https://github.com/tatari-tv/claude-pricing", tag = "v0.1.0", version = "0.1.0", features = ["fetch"] }
+claude-pricing = { git = "https://github.com/tatari-tv/claude-pricing", tag = "v0.1.1", version = "0.1.1", features = ["fetch"] }
 comfy-table = "7.1"
 clap = { version = "4.5.60", features = ["derive", "env"] }
 dirs = "6.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccu"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 authors = ["Scott Idler <scott.a.idler@gmail.com>"]
 build = "build.rs"


### PR DESCRIPTION
## Summary
- Updates the `claude-pricing` git dep tag from v0.1.0 to v0.1.1.
- Brings in the refreshed embedded pricing baseline (`data/pricing.json`), the dual-parser cron pipeline, and the new README. No `src/` changes between the two tags, so this is a no-op for runtime behavior beyond the new compiled-in baseline.

## Test plan
- [x] `cargo check` passes locally
- [ ] CI green