### PR TITLE
chore: re-pin claude-pricing to v2.0.0 (schema 2); ccu v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "ccu"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "clap",
@@ -206,8 +206,8 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "claude-pricing"
-version = "0.2.0"
-source = "git+https://github.com/tatari-tv/claude-pricing?tag=v0.2.0#a5d58395c42479a56efba169fa2959489033d8b6"
+version = "2.0.0"
+source = "git+https://github.com/tatari-tv/claude-pricing?tag=v2.0.0#3d3d30e7fd1c593c1150ee5bd84abbf9f262750a"
 dependencies = [
  "chrono",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccu"
-version = "0.4.5"
+version = "0.5.0"
 edition = "2024"
 authors = ["Scott Idler <scott.a.idler@gmail.com>"]
 build = "build.rs"
@@ -8,7 +8,7 @@ description = "Fast CLI tool for tracking Claude Code session costs from JSONL l
 
 [dependencies]
 chrono = "0.4.44"
-claude-pricing = { git = "https://github.com/tatari-tv/claude-pricing", tag = "v0.2.0", version = "0.2.0", features = ["fetch"] }
+claude-pricing = { git = "https://github.com/tatari-tv/claude-pricing", tag = "v2.0.0", version = "2.0.0", features = ["fetch"] }
 comfy-table = "7.1"
 clap = { version = "4.5.60", features = ["derive", "env"] }
 dirs = "6.0.0"


### PR DESCRIPTION
Re-pins `claude-pricing` to the schema-2 release `v2.0.0` and minor-bumps ccu to `v0.5.0`.

- `claude-pricing`: `tag/version v0.2.0` → `v2.0.0` (crate major now tracks feed `schema_version`; v2 == schema 2).
- Picks up data-driven model-ID normalization + the fetch cache-poisoning fix.
- `otto ci` green (79 tests).

After merge: tag `v0.5.0` on main.